### PR TITLE
Fix messaging and slider.

### DIFF
--- a/cooldowns.lua
+++ b/cooldowns.lua
@@ -193,9 +193,11 @@ for _, id in pairs(spells) do
     local name, _, icon = GetSpellInfo(id)
     v.icon = info.itemId and select(5, GetItemInfoInstant(info.itemId)) or icon
     v.spellName = name
-    -- Remove transmute prefix.
-    if name:find("Transmute:") then
-        name = string.match(name, "Transmute: (.*)")
+    -- Remove transmute prefix, trying to ignore languages by just using :, 
+    -- in the future we may have non transmutes with :.
+    local i = name:find(":")
+    if i then
+        name = string.sub(name, i + 2)
         v.transmute = true
     end
     v.name = name
@@ -230,8 +232,9 @@ for id, v in pairs(items) do
     item:ContinueOnItemLoad(function()
         v.name = item:GetItemName()
         v.itemName = v.name
-        if v.name:find("Wormhole Generator:") then
-            v.name = string.match(v.name, "Wormhole Generator: (.*)")
+        local i = v.name:find(":")
+        if i then
+            v.name = string.sub(v.name, i + 2)
         end
         v.icon = item:GetItemIcon()
         -- Make sure function is loaded.

--- a/events.lua
+++ b/events.lua
@@ -227,7 +227,8 @@ local function messageResults(player, instance)
                 local available = instance:availableCurrency(currency)
                 local collected = max - available
                 local total = player:totalCurrency(currency)
-                local text = string.format("[%s] %s, collected %s of %s [%s]", addOnName, currency:getNameWithIcon(), collected, max, total)
+                -- I don't know or I can't put an icon into chat.
+                local text = string.format("[%s] %s, collected %s of %s [%s]", addOnName, currency:getName(), collected, max, total)
                 Options:PrintMessage(text)
             end
         end
@@ -248,6 +249,8 @@ end
 local broadcastFrame = CreateFrame("Frame")
 broadcastFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 broadcastFrame:SetScript("OnEvent", broadcastEvent)
+-- On reload set the instance.
+C_Timer.After(0.5, broadcastEvent)
 
 SLASH_InstanceCurrencyTracker1 = "/ict";
 SlashCmdList.InstanceCurrencyTracker = function(msg)

--- a/ui/ui.lua
+++ b/ui/ui.lua
@@ -185,10 +185,16 @@ function UI:openDeleteFrame(player)
 end
 
 local options = createDialogWindow("ICTResetOptionsDialog", "Confirm Reset Options", "Set all options to their default value?", "Confirm")
+local resetOptions = true
 function UI:openResetOptionsFrame()
     return function()
+        resetOptions = not resetOptions
+        if resetOptions then
+            options:Hide()
+            return
+        end
         options:Show()
-        options.button:SetScript("OnClick", function ()
+        options.button:SetScript("OnClick", function()
             ICT.Options:setDefaultOptions(true)
             options:Hide()
         end)
@@ -349,7 +355,9 @@ function UI:CreatePlayerSlider()
         local value = frame:GetText();
         value = tonumber(value);
         if value then
+            value = math.max(math.min(ICT.MaxLevel, value), 1)
             ICT.db.options.minimumLevel = value
+            levelSlider:SetValue(value)
             levelSlider.editBox:SetText(value)
             frame:ClearFocus()
         else


### PR DESCRIPTION
- Level text box updates slider
- Level text box uses max/min 1-80
- clicking reset options again closes menu
- fix message on leaving instance due to icon
- strip `:` for all cooldowns to hopefully ignore languages (assuming they are including in all languages...)